### PR TITLE
Add series to Blacklight search fields

### DIFF
--- a/lib/ebsco/eds/options.rb
+++ b/lib/ebsco/eds/options.rb
@@ -364,6 +364,8 @@ module EBSCO
                     _field_code = 'IB'
                   when 'descriptor'
                     _field_code = 'DE'
+                  when 'series'
+                    _field_code = 'SE'
                 end
               end
 

--- a/test/solr_query_test.rb
+++ b/test/solr_query_test.rb
@@ -39,6 +39,7 @@ class EdsApiTests < Minitest::Test
       results8 = session.search({'q' => '9781443816281', 'start' => 0, 'rows' => 1, 'search_field' => 'isbn'})
       results9 = session.search({'q' => 'sheiber', 'start' => 0, 'rows' => 1, 'search_field' => 'author'})
       results10 = session.search({'q' => 'climate change', 'start' => 0, 'rows' => 1, 'search_field' => 'descriptor'})
+      results11 = session.search({'q' => 'climate change', 'start' => 0, 'rows' => 1, 'search_field' => 'series'})
       refute_nil results1
       refute_nil results2
       refute_nil results3
@@ -49,6 +50,7 @@ class EdsApiTests < Minitest::Test
       refute_nil results8
       refute_nil results9
       refute_nil results10
+      refute_nil results11
       session.end
     end
   end


### PR DESCRIPTION
Related to [sul-dlss/SearchWorks #1588](https://github.com/sul-dlss/SearchWorks/issues/1588)

This PR adds field code `SE` to the Blacklight search fields as `Series`. 