### PR TITLE
Capture for NotFound and BadRequest errors when retrieving a list of …

### DIFF
--- a/lib/ebsco/eds/session.rb
+++ b/lib/ebsco/eds/session.rb
@@ -480,9 +480,13 @@ module EBSCO
           list.each.with_index(1) { |id, index|
             dbid = id.split('__',2).first
             accession = id.split('__',2).last
-            current_rec = retrieve(dbid: dbid, an: accession, highlight: highlight, ebook: @config[:ebook_preferred_format])
-            current_rec.eds_result_id = index
-            records.push current_rec
+            begin
+              current_rec = retrieve(dbid: dbid, an: accession, highlight: highlight, ebook: @config[:ebook_preferred_format])
+              current_rec.eds_result_id = index
+              records.push current_rec
+            rescue EBSCO::EDS::BadRequest, EBSCO::EDS::NotFound => e
+              puts "Request for #{id} in #{self.class.name}#solr_retrieve_list failed with #{e}" if @debug
+            end
           }
         end
         r = empty_results(records.length)


### PR DESCRIPTION
…documents by ID.

Closes #95

Submitting this in response to a user report that they could not access their article selections due to our access to a particular database going away sul-dlss/SearchWorks#2469

I don't know if this is the way you ultimately want to handle this sort of thing or not so feel free to close this and handle the issue in a more appropriate way.

Also, I'm not super familiar w/ VCR and not sure how this sort of thing should be tested in the edsapi-ruby codebase (if you decide that this is an acceptable approach).  If you point me in the right direction, I would happily write an automated test for this. FWIW I'm getting the 3 failures that this build is seeing on master, so I'm not sure the build would pass anyway.
