### PR TITLE
If no results are returned and config is set to use SmartText as a failover, rerun search in SmartText mode

### DIFF
--- a/lib/ebsco/eds/configuration.rb
+++ b/lib/ebsco/eds/configuration.rb
@@ -59,7 +59,8 @@ module EBSCO
             :ris_link_find => '',
             :ris_link_replace => '',
             :ris_db_find => '',
-            :ris_db_replace => ''
+            :ris_db_replace => '',
+            :smarttext_failover => false
         }
         @valid_config_keys = @config.keys
       end

--- a/lib/ebsco/eds/results.rb
+++ b/lib/ebsco/eds/results.rb
@@ -29,7 +29,7 @@ module EBSCO
 
       # Creates search results from the \EDS API search response. It includes information about the results and a list
       # of Record items.
-      def initialize(search_results, eds_config = {}, additional_limiters = {}, options = {})
+      def initialize(search_results, eds_config = {}, additional_limiters = {}, options = {}, smarttext_failover = false)
 
         @results = search_results
 
@@ -102,6 +102,9 @@ module EBSCO
 
           # titleize facets
           @titleize_facets = %w[Language Journal SubjectEDS SubjectGeographic Publisher]
+
+          # set flag that query was rerun with smarttext after no results were found
+          @smarttext_failover = smarttext_failover
 
         else
           # response isn't a hash (eg, html error page)

--- a/lib/ebsco/eds/version.rb
+++ b/lib/ebsco/eds/version.rb
@@ -1,5 +1,5 @@
 module EBSCO
   module EDS
-    VERSION = '1.0.9'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
[US679422](https://rally1.rallydev.com/#/detail/userstory/408028789436?fdp=true): Failover to SmartText Search option in Ruby Gem

Creates new config key "smarttext_failover" defaulted to false. 

If application sets this value to true, and the search query returned no results, the session will flip the search mode to "smart" and rerun the search. On this second search, we send a flag to the results class identifying this search as a being run as a failover. 

The results class now returns a value called "smarttext_failover" which will be set to true or false depending on if the search performed was as part of a failover search.

Open Questions:
- [ ] Does the to_solr results response need the "smarttext_failover" value included? Or is it enough to only have it in the main results response?

To Test:
- In irb create a new session with no smarttext_failover config option set: `session = EBSCO::EDS::Session.new({:user=>'username', :pass=>'password', :profile=>'profile'})` In the returned session object, you should see `:smarttext_failover=>false` in the @config variable.
- Do a normal search for anything that will return results and note that the search mode is the default mode for the API profile `"SearchMode"=>"all"`. Note that the results send back a value `@smarttext_failover=false`
- Do a search for something that will not return results. Note that the search mode is still the default mode, and the @smarttext_failover value is still false.
- Create a new session, this time setting smarttext_failover to be true: `session = EBSCO::EDS::Session.new({:user=>'username', :pass=>'password', :profile=>'profile', :smarttext_failover=>true})` In the returned session object, you should see `:smarttext_failover=>true`. In the returned session object, you should see `:smarttext_failover=>true` in the @config variable.
- Do a normal search for anything that will return results and note that the search mode is the default mode for the API profile `"SearchMode"=>"all"`. Note that the results send back a value `@smarttext_failover=false`
- Do a search for something that will not return results using a non-smart search mode, but will return results using SmartText: 
```
results = session.search({query: 'we should build coalitions amongst the working class left by taking a page out of the visionary 1970s Black feminist socialist Combahee River Collective bonding over our shared working class identities while also acknowledging centering and learning the myraid of ways that capitalism oppresses through the identities of the groups most marginalized members', results_per_page: 5 })
```
- Note that the search mode used was "smart" and the @smarttext_failover value is "true"
