### PR TITLE
Make sanitize gem dependency optional

### DIFF
--- a/ebsco-eds.gemspec
+++ b/ebsco-eds.gemspec
@@ -54,5 +54,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 5.0', '>= 5.0.0'
   spec.add_development_dependency 'minitest-vcr', '~> 1.4', '>= 1.4.0'
   spec.add_development_dependency 'webmock', '~> 3.6'
+  spec.add_development_dependency 'sanitize', '~> 5.0'
 
 end

--- a/ebsco-eds.gemspec
+++ b/ebsco-eds.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'csl-styles', '~> 1.0', '>= 1.0.1.5'
   spec.add_dependency 'activesupport', '>= 5.2', '< 6.1'
   spec.add_dependency 'net-http-persistent', '~> 3.1'
-  spec.add_dependency 'sanitize', '~> 5.0'
   spec.add_dependency 'public_suffix', '~>4.0'
 
   spec.add_development_dependency 'bundler'

--- a/lib/ebsco/eds/error.rb
+++ b/lib/ebsco/eds/error.rb
@@ -46,5 +46,8 @@ module EBSCO
     # raised when connection fails
     class ConnectionFailed < Error; end
 
+    # raised when missing a dependency
+    class MissingDependency < Error; end
+
   end
 end

--- a/lib/ebsco/eds/record.rb
+++ b/lib/ebsco/eds/record.rb
@@ -1,7 +1,6 @@
 require 'yaml'
 require 'json'
 require 'cgi'
-require 'sanitize'
 
 module EBSCO
 
@@ -151,6 +150,9 @@ module EBSCO
         if ENV.has_key? 'EDS_DECODE_SANITIZE_HTML'
           @decode_sanitize_html = ENV['EDS_DECODE_SANITIZE_HTML']
         end
+
+        require_sanitize if @decode_sanitize_html
+
 
         if results_record.key? 'Record'
           @record = results_record['Record'] # single record returned by retrieve api
@@ -1003,6 +1005,12 @@ module EBSCO
           end.join('&lt;br /&gt;')
         end
         subjects
+      end
+
+      def require_sanitize
+        require 'sanitize'
+      rescue Gem::LoadError, LoadError
+        raise EBSCO::EDS::MissingDependency.new 'Sanitize is turned on, but the sanitize gem is not loaded'
       end
 
     end # Class Record


### PR DESCRIPTION
Thanks for this great gem!  Our app runs on jruby, which is unfortunately not compatible with the sanitize gem (see https://github.com/rgrove/sanitize/issues/166)

All of the sanitize logic can be turned off by a configuration setting, but there are still two things that need to be fixed in order to run the ebsco-eds gem on jruby:

- Remove the dependency from the gemspec
- Only call the "require" statement for sanitize if the user actually wants to use the sanitize behavior.