### PR TITLE
Feature/smarttext failover reader

### DIFF
--- a/lib/ebsco/eds/results.rb
+++ b/lib/ebsco/eds/results.rb
@@ -17,6 +17,8 @@ module EBSCO
       attr_accessor :records
       # Array of EBSCO::EDS::Record Research Starters
       attr_reader :research_starters
+      # Bool
+      attr_reader :smarttext_failover
       # Array of EBSCO::EDS::Record Exact Publication Matches
       attr_reader :publication_match
 

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -14,6 +14,7 @@ class EdsApiTests < Minitest::Test
       refute_nil results.search_queries
       refute_nil results.page_number
       refute_nil results.search_criteria
+      refute_nil results.smarttext_failover
       assert results.search_terms == ['volcano']
       session.end
     end


### PR DESCRIPTION
Addresses https://github.com/ebsco/edsapi-ruby/issues/100 - whether a search failed over to smarttext searching or not is now exposed in readable attribute `smarttext_failover`

```
session = EBSCO::EDS::Session.new({:user=>'SOMEUSER', :pass=>'SOMEPASSWORD', :profile=>'SOMEPROFILE', :smarttext_failover=>true})

results = session.search({:query => 'we should build coalitions amongst the working class left by taking a page out of the visionary 1970s Black feminist socialist Combahee River Collective bonding over our shared working class identities while also acknowledging centering and learning the myraid of ways that capitalism oppresses through the identities of the groups most marginalized members'})

results.smarttext_failover # => true

results = session.search({:query => 'collective'})

results.smarttext_failover # => false
```

Superficial testing of the accessor added, but I see that we didn't really test this smarttext failover feature at all.  Will open a new issue to get coverage of that.