### PR TITLE
Loosening upper bound of activesupport

### DIFF
--- a/ebsco-eds.gemspec
+++ b/ebsco-eds.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'csl', '>= 1.4.0', '< 1.6'
   spec.add_dependency 'citeproc-ruby', '~> 1.0', '>= 1.0.2'
   spec.add_dependency 'csl-styles', '~> 1.0', '>= 1.0.1.5'
-  spec.add_dependency 'activesupport', '>= 5.2', '< 6.1'
+  spec.add_dependency 'activesupport', '>= 5.2'
   spec.add_dependency 'net-http-persistent', '~> 3.1'
   spec.add_dependency 'public_suffix', '~>4.0'
 

--- a/lib/ebsco/eds/version.rb
+++ b/lib/ebsco/eds/version.rb
@@ -1,5 +1,5 @@
 module EBSCO
   module EDS
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end


### PR DESCRIPTION
Loosened dependencies on Rails / Active Support.

https://github.com/ebsco/edsapi-ruby/issues/109

@JPrevost - let us know if this looks fine to you.  We tested with activesupport 6.1.3.1 and it seemed fine - test suite passed 100%, manual testing seemed to go fine.  We just removed the upper bound.  

Still relatively new to the Ruby OSS community, so holler if you'd advise still imposing some kind of upper bound restriction, but if this works for you, it works for us!  We'll publish this release after merging.