### PR TITLE
Allow Ruby 3 support

### DIFF
--- a/ebsco-eds.gemspec
+++ b/ebsco-eds.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'citeproc-ruby', '~> 1.0', '>= 1.0.2'
   spec.add_dependency 'csl-styles', '~> 1.0', '>= 1.0.1.5'
   spec.add_dependency 'activesupport', '>= 5.2'
-  spec.add_dependency 'net-http-persistent', '~> 3.1'
+  spec.add_dependency 'net-http-persistent', '>= 3.1', '< 5'
   spec.add_dependency 'public_suffix', '~>4.0'
 
   spec.add_development_dependency 'bundler'

--- a/lib/ebsco/eds/session.rb
+++ b/lib/ebsco/eds/session.rb
@@ -326,11 +326,11 @@ module EBSCO
         payload = { DbId: dbid, An: an, HighlightTerms: highlight, EbookPreferredFormat: ebook }
         retrieve_response = do_request(:post, path: @config[:retrieve_url], payload: payload)
         record = EBSCO::EDS::Record.new(retrieve_response, @config)
-        record_citation_exports = get_citation_exports({dbid: dbid, an: an, format: @config[:citation_exports_formats]})
+        record_citation_exports = get_citation_exports(dbid: dbid, an: an, format: @config[:citation_exports_formats])
         unless record_citation_exports.nil?
           record.set_citation_exports(record_citation_exports)
         end
-        record_citation_styles = get_citation_styles({dbid: dbid, an: an, format: @config[:citation_styles_formats]})
+        record_citation_styles = get_citation_styles(dbid: dbid, an: an, format: @config[:citation_styles_formats])
         unless record_citation_styles.nil?
           record.set_citation_styles(record_citation_styles)
         end

--- a/test/citation_test.rb
+++ b/test/citation_test.rb
@@ -6,7 +6,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citations') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '108974507'})
+        record = session.retrieve(dbid: 'asn', an: '108974507')
         citation_exports = record.eds_citation_exports
         citation_styles = record.eds_citation_styles
         assert citation_exports.items.first['data'].include?('polymeric chains and tailor their functionalities')
@@ -25,7 +25,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_not_found_bad_record') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        styles = session.get_citation_styles({dbid: 'asn', an: '999999'})
+        styles = session.get_citation_styles(dbid: 'asn', an: '999999')
         assert styles.items.first['error'] == "Record not found"
         assert styles.items.first['data'] == ""
 
@@ -40,7 +40,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_exports_not_found_bad_record') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        exports = session.get_citation_exports({dbid: 'asn', an: '999999'})
+        exports = session.get_citation_exports(dbid: 'asn', an: '999999')
         assert exports.items.first['error'] == "Record not found"
       else
         puts 'WARNING: skipping test_journal_citation_exports_not_found_bad_record since asn db not in profile.'
@@ -53,7 +53,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_style_one_specified') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        mla_style = session.get_citation_styles({dbid: 'asn', an: '108974507', format: 'mla'})
+        mla_style = session.get_citation_styles(dbid: 'asn', an: '108974507', format: 'mla')
         assert mla_style.items.count == 1
         assert mla_style.items.first['id'] == 'mla'
       else
@@ -67,7 +67,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_export_one_specified') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        ris_export = session.get_citation_exports({dbid: 'asn', an: '108974507', format: 'ris'})
+        ris_export = session.get_citation_exports(dbid: 'asn', an: '108974507', format: 'ris')
         assert ris_export.items.count == 1
         assert ris_export.items.first['id'] == 'RIS'
         refute_nil ris_export.items.first['data']
@@ -82,7 +82,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_export_one_specified_unsupported') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        bogus_export = session.get_citation_exports({dbid: 'asn', an: '108974507', format: 'bogus'})
+        bogus_export = session.get_citation_exports(dbid: 'asn', an: '108974507', format: 'bogus')
         bogus_export.items.first['error'] == "Invalid citation export format"
       else
         puts 'WARNING: skipping test_journal_citation_export_one_specified_unsupported since asn db not in profile.'
@@ -95,7 +95,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_style_list_specified') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        list_of_styles = session.get_citation_styles({dbid: 'asn', an: '108974507', format: 'mla,apa'})
+        list_of_styles = session.get_citation_styles(dbid: 'asn', an: '108974507', format: 'mla,apa')
         assert list_of_styles.items.count == 2
         mla_style = list_of_styles.items.select { |item| item['id'] == 'mla' }
         refute_nil mla_style
@@ -113,7 +113,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_style_list_specified_one_bad') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        list_of_styles = session.get_citation_styles({dbid: 'asn', an: '108974507', format: 'mla,bogus'})
+        list_of_styles = session.get_citation_styles(dbid: 'asn', an: '108974507', format: 'mla,bogus')
         assert list_of_styles.items.count == 2
         mla_style = list_of_styles.items.select { |item| item['id'] == 'mla' }
         refute_nil mla_style
@@ -131,7 +131,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_journal_citation_export_list_specified') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        list_of_exports = session.get_citation_exports({dbid: 'asn', an: '108974507', format: 'ris,bibtex'})
+        list_of_exports = session.get_citation_exports(dbid: 'asn', an: '108974507', format: 'ris,bibtex')
         assert list_of_exports.items.first['error'] == "Invalid citation export format"
       else
         puts 'WARNING: skipping test_journal_citation_export_list_specified since asn db not in profile.'
@@ -144,7 +144,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_book_citations') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'cat02060a', an: 'd.uga.3690122'})
+        record = session.retrieve(dbid: 'cat02060a', an: 'd.uga.3690122')
         citation_exports = record.eds_citation_exports
         citation_styles = record.eds_citation_styles
         assert citation_exports.items.count == 1
@@ -163,7 +163,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_conference_citations') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '118411536'})
+        record = session.retrieve(dbid: 'asn', an: '118411536')
         citation_exports = record.eds_citation_exports
         citation_styles = record.eds_citation_styles
         assert citation_exports.items.count == 1
@@ -200,7 +200,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_specified_styles_in_config') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api', citation_styles_formats: 'apa,mla,chicago'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '108974507'})
+        record = session.retrieve(dbid: 'asn', an: '108974507')
         citation_styles = record.eds_citation_styles
         style_items = citation_styles.items
         assert style_items.count >= 3
@@ -227,7 +227,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_citations_keep_links') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api', citation_link_find: ''})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '118411536'})
+        record = session.retrieve(dbid: 'asn', an: '118411536')
         citation_exports = record.eds_citation_exports
         citation_styles = record.eds_citation_styles
         assert citation_exports.items.first['data'].include?('UR  - http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=asn&AN=118411536')
@@ -252,7 +252,7 @@ class EdsApiTests < Minitest::Test
                                          debug: false
                                         })
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '118411536'})
+        record = session.retrieve(dbid: 'asn', an: '118411536')
         citation_exports = record.eds_citation_exports
         citation_styles = record.eds_citation_styles
         # assert(!citation_exports.items.first['data'].include?('UR  - http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=asn&AN=118411536'))
@@ -272,7 +272,7 @@ class EdsApiTests < Minitest::Test
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api',
                                          citation_link_find: '[.,]\s+(&lt;i&gt;EBSCOhost|viewed|Available|Retrieved from|http:\/\/search.ebscohost.com|Disponível em).+$'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '118411536'})
+        record = session.retrieve(dbid: 'asn', an: '118411536')
         citation_styles = record.eds_citation_styles
         abnt_style = citation_styles.items.select { |item| item['id'] == 'abnt' }
         assert(!abnt_style.first['data'].include?('search.ebscohost.com'))
@@ -287,7 +287,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('citation_test/profile_1/test_citations_include_doi') do
       session = EBSCO::EDS::Session.new({use_cache: false, guest: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '108974507'})
+        record = session.retrieve(dbid: 'asn', an: '108974507')
         citation_styles = record.eds_citation_styles
         style_items = citation_styles.items
         assert style_items.count >= 9
@@ -311,7 +311,7 @@ class EdsApiTests < Minitest::Test
                                          citation_db_find: '<i>EBSCOhost<\/i>',
                                          citation_db_replace: '<i>SearchWorks</i>'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'edsbas', an: 'edsbas.AA261780'})
+        record = session.retrieve(dbid: 'edsbas', an: 'edsbas.AA261780')
         citation_styles = record.eds_citation_styles
         style_items = citation_styles.items
         assert style_items.count >= 9
@@ -339,7 +339,7 @@ class EdsApiTests < Minitest::Test
                                          citation_db_find: '<i>EBSCOhost<\/i>',
                                          citation_db_replace: '<i>SearchWorks</i>'})
       if session.dbid_in_profile 'edsdoj'
-        record = session.retrieve({dbid: 'edsgpr', an: 'edsgpr.001022076'})
+        record = session.retrieve(dbid: 'edsgpr', an: 'edsgpr.001022076')
         citation_styles = record.eds_citation_styles
         style_items = citation_styles.items
         assert style_items.count >= 9
@@ -373,7 +373,7 @@ class EdsApiTests < Minitest::Test
                                         })
 
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'edsbas', an: 'edsbas.AA261780'})
+        record = session.retrieve(dbid: 'edsbas', an: 'edsbas.AA261780')
         citation_exports = record.eds_citation_exports
         # puts citation_exports.items.first['data'].inspect
         assert citation_exports.items.first['data'].include?('UR  - https://searchworks.stanford.edu/articles/edsbas__edsbas.AA261780')
@@ -398,7 +398,7 @@ class EdsApiTests < Minitest::Test
                                         })
 
       if session.dbid_in_profile 'edsgpr'
-        record = session.retrieve({dbid: 'edsgpr', an: 'edsgpr.001022076'})
+        record = session.retrieve(dbid: 'edsgpr', an: 'edsgpr.001022076')
         citation_exports = record.eds_citation_exports
         # puts citation_exports.items.first['data']
         assert citation_exports.items.first['data'].include?('UR  - https://searchworks.stanford.edu/articles/edsgpr__edsgpr.001022076')
@@ -423,7 +423,7 @@ class EdsApiTests < Minitest::Test
                                         })
 
       if session.dbid_in_profile 'edsgpr'
-        record = session.retrieve({dbid: 'edsgpr', an: 'edsgpr.001022076'})
+        record = session.retrieve(dbid: 'edsgpr', an: 'edsgpr.001022076')
         citation_exports = record.eds_citation_exports
         assert !citation_exports.items.first['data'].include?('UR  - https://stanford.idm.oclc.org/login?')
         assert !citation_exports.items.first['data'].include?('DP  - EBSCOhost')

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -22,12 +22,12 @@ class EdsApiTests < Minitest::Test
                                                        all_subjects_search_links: true})
       if session_with_sanitize.dbid_in_profile 'cmedm'
 
-        record = session_with_orig_field_codes.retrieve({dbid: 'cmedm', an: '27748641'})
+        record = session_with_orig_field_codes.retrieve(dbid: 'cmedm', an: '27748641')
 
-        record = session_with_sanitize.retrieve({dbid: 'cmedm', an: '27748641'})
+        record = session_with_sanitize.retrieve(dbid: 'cmedm', an: '27748641')
         assert record.eds_subjects_mesh.to_s == '<searchLink fieldcode="DE" term="%22Nanotubes%2C+Carbon%22">Nanotubes, Carbon*</searchLink> <br><searchLink fieldcode="DE" term="%22Water+Pollutants%2C+Chemical%22">Water Pollutants, Chemical*</searchLink><br><searchLink fieldcode="DE" term="%22Catalysis%22">Catalysis</searchLink> ; <searchLink fieldcode="DE" term="%22Hydrogen+Peroxide%22">Hydrogen Peroxide</searchLink> ; <searchLink fieldcode="DE" term="%22Ozone%22">Ozone</searchLink>'
 
-        record = session_no_sanitize.retrieve({dbid: 'cmedm', an: '27748641'})
+        record = session_no_sanitize.retrieve(dbid: 'cmedm', an: '27748641')
         assert record.eds_subjects_mesh.to_s == '&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Nanotubes%2C+Carbon%22&quot;&gt;Nanotubes, Carbon*&lt;/searchLink&gt; &lt;br /&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Water+Pollutants%2C+Chemical%22&quot;&gt;Water Pollutants, Chemical*&lt;/searchLink&gt;&lt;br /&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Catalysis%22&quot;&gt;Catalysis&lt;/searchLink&gt; ; &lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Hydrogen+Peroxide%22&quot;&gt;Hydrogen Peroxide&lt;/searchLink&gt; ; &lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Ozone%22&quot;&gt;Ozone&lt;/searchLink&gt;'
 
        # puts record.eds_subjects_mesh.to_s
@@ -61,7 +61,7 @@ class EdsApiTests < Minitest::Test
                                                        decode_sanitize_html: true,
                                                        all_subjects_search_links: true})
       if session_with_sanitize.dbid_in_profile 'cmedm'
-        record = session_with_sanitize.retrieve({dbid: 'cmedm', an: '27748641'})
+        record = session_with_sanitize.retrieve(dbid: 'cmedm', an: '27748641')
         assert record.eds_authors_composed.to_s.include? '<searchLink fieldcode="AU" term="%22Bai+Z%22">Bai Z</searchLink>'
       else
         puts "WARNING: skipping test_author_html_sanitize, cmedm db isn't in the profile."
@@ -79,7 +79,7 @@ class EdsApiTests < Minitest::Test
                                                      all_subjects_search_links: true})
 
     if session_with_sanitize.dbid_in_profile 'bah'
-      record = session_with_sanitize.retrieve({dbid: 'bah', an: '116897973'})
+      record = session_with_sanitize.retrieve(dbid: 'bah', an: '116897973')
       #puts 'HTML AFTER: ' + record.eds_html_fulltext.to_s
       assert record.eds_html_fulltext.to_s.include? '<h1 id="AN0116897973-3">YOU\'VE GOT TO BE KITTEN ME!&nbsp;</h1>'
     else
@@ -99,7 +99,7 @@ class EdsApiTests < Minitest::Test
                                                        all_subjects_search_links: true})
 
       if session_with_sanitize.dbid_in_profile 'aph'
-        record = session_with_sanitize.retrieve({dbid: 'aph', an: '87564228'})
+        record = session_with_sanitize.retrieve(dbid: 'aph', an: '87564228')
         # puts 'HTML AFTER: ' + record.eds_html_fulltext.to_s
         assert record.eds_html_fulltext.to_s.include? '<h1 id="AN0087564228-1">Expressing Compassion in the Face of Crisis'
       else

--- a/test/linking_test.rb
+++ b/test/linking_test.rb
@@ -6,7 +6,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('linking_test/profile_3/test_smartlinks', :allow_playback_repeats => true) do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edslinkapi'})
       if session.dbid_in_profile 'cmedm'
-        record = session.retrieve({dbid: 'cmedm', an: '27788591'})
+        record = session.retrieve(dbid: 'cmedm', an: '27788591')
         # now its a pdf for some reason?
         assert record.fulltext_link[:type] == 'pdf'
         assert record.bib_issn_electronic == '1556-9519'
@@ -21,7 +21,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('linking_test/profile_3/test_customlinks_fulltext', :allow_playback_repeats => true) do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edslinkapi'})
       if session.dbid_in_profile 'edsoai'
-        record = session.retrieve({dbid: 'edsoai', an: 'edsoai.975318230'})
+        record = session.retrieve(dbid: 'edsoai', an: 'edsoai.975318230')
         found_catalog_link = false
         found_custom_fulltext = false
         record.fulltext_links.each do |link|
@@ -40,7 +40,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('linking_test/profile_2/test_customlinks_fulltext_missing_protocol', :allow_playback_repeats => true) do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
       if session.dbid_in_profile 'eric'
-        record = session.retrieve({dbid: 'eric', an: 'EJ1050530'})
+        record = session.retrieve(dbid: 'eric', an: 'EJ1050530')
         found_customlink_fulltext = false
         found_protocol = false
         record.fulltext_links.each do |link|
@@ -61,7 +61,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('linking_test/profile_3/test_non_fulltext_links', :allow_playback_repeats => true) do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edslinkapi'})
       if session.dbid_in_profile 'cat02069a'
-        record = session.retrieve({dbid: 'cat02069a', an: 'd.mvs.601243'})
+        record = session.retrieve(dbid: 'cat02069a', an: 'd.mvs.601243')
         assert record.non_fulltext_links.first[:type] == 'customlink-other'
         found_catalog_link = false
         found_custom_other = false

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -7,7 +7,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_journal_article') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '108974507'})
+        record = session.retrieve(dbid: 'asn', an: '108974507')
         assert record.eds_accession_number == '108974507'
         assert record.eds_database_id == 'asn'
         assert record.eds_database_name == 'Academic Search Ultimate'
@@ -52,7 +52,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_journal_multiple_authors') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '119572050'})
+        record = session.retrieve(dbid: 'asn', an: '119572050')
         refute_nil record.eds_subjects_geographic
         assert record.eds_authors.include? 'Becerril, L.'
         assert record.eds_author_affiliations.include? 'University of Granada'
@@ -68,7 +68,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_ebook') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'e000xna'
-        record = session.retrieve({dbid: 'e000xna', an: '553416'})
+        record = session.retrieve(dbid: 'e000xna', an: '553416')
         assert record.eds_publication_info == 'Newcastle upon Tyne : Cambridge Scholars Publishing. 2009'
         assert record.eds_isbn_electronic == '9781443816281'
         assert record.eds_isbn_print == '9781443813945'
@@ -91,7 +91,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_conference') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '118411536'})
+        record = session.retrieve(dbid: 'asn', an: '118411536')
         assert record.eds_document_type == 'Article'
         assert record.eds_publication_type == 'Conference'
         refute_nil record.eds_author_supplied_keywords
@@ -107,7 +107,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_newspaper') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '112761583'})
+        record = session.retrieve(dbid: 'asn', an: '112761583')
         assert record.eds_document_type == 'Article'
         assert record.eds_publication_type == 'News'
         assert record.eds_html_fulltext.include? 'The Curious Incident of the Dog'
@@ -125,7 +125,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_score') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'cat02060a'
-        session.retrieve({dbid: 'cat02060a', an: 'd.uga.3690112'})
+        session.retrieve(dbid: 'cat02060a', an: 'd.uga.3690112')
       else
         puts "WARNING: skipping test_retrieve_score test, cat02060a db isn't in the profile."
       end
@@ -138,7 +138,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_book') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'cat02060a'
-        record = session.retrieve({dbid: 'cat02060a', an: 'd.uga.3690122'})
+        record = session.retrieve(dbid: 'cat02060a', an: 'd.uga.3690122')
         #puts record.to_yaml
         refute_nil record.eds_physical_description
         refute_nil record.eds_subjects_person
@@ -156,7 +156,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_epub_book') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'e000xna'
-        record = session.retrieve({dbid: 'e000xna', an: '719559', ebook: 'ebook-epub'})
+        record = session.retrieve(dbid: 'e000xna', an: '719559', ebook: 'ebook-epub')
         # puts record.to_yaml
         assert record.fulltext_links.first()[:type] == 'ebook-epub'
         assert record.fulltext_links.first()[:url] == 'http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=e000xna&AN=719559&ebv=EK&ppid='
@@ -172,7 +172,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_retrieve_ir_article') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'edshld'
-        record = session.retrieve({dbid: 'edshld', an: 'edshld.1.3372911'})
+        record = session.retrieve(dbid: 'edshld', an: 'edshld.1.3372911')
         # puts record.to_yaml
         assert record.fulltext_links.first()[:type] == 'cataloglink'
         assert record.fulltext_links.first()[:url] == 'http://nrs.harvard.edu/urn-3:HUL.InstRepos:3372911'
@@ -187,7 +187,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_record_to_solr_with_fulltext') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'ers'
-        record = session.retrieve({dbid: 'ers', an: '100039113'})
+        record = session.retrieve(dbid: 'ers', an: '100039113')
         refute_nil record.to_solr
       else
         puts "WARNING: skipping test_record_to_solr_with_fulltext test, ers db isn't in the profile."
@@ -200,7 +200,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_1/test_record_to_solr_with_doi') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds-api'})
       if session.dbid_in_profile 'asn'
-        record = session.retrieve({dbid: 'asn', an: '121479599'})
+        record = session.retrieve(dbid: 'asn', an: '121479599')
         refute_nil record.to_solr
       else
         puts "WARNING: skipping test_record_to_solr_with_doi test, asn db isn't in the profile."
@@ -214,7 +214,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_2/test_record_with_number_other_items') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
       if session.dbid_in_profile 'edshtl'
-        record = session.retrieve({dbid: 'edshtl', an: 'pur1.32754078701863'})
+        record = session.retrieve(dbid: 'edshtl', an: 'pur1.32754078701863')
         assert record.eds_extras_number_other_SuDoc == 'Y 4.J 89/1:109-84'
       else
         puts "WARNING: skipping test_record_with_number_other_items test, edshtl db isn't in the profile."
@@ -228,7 +228,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_2/test_retrieve_accession_number_with_dot') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
       if session.dbid_in_profile 'edsagr'
-        record = session.retrieve({dbid: 'edsagr', an: 'edsagr.US201600263208'})
+        record = session.retrieve(dbid: 'edsagr', an: 'edsagr.US201600263208')
         assert record.eds_title == 'Effects of glyphosate-based herbicides on survival, development, growth and sex ratios of wood frogs (Lithobates sylvaticus) tadpoles. I: Chronic laboratory exposures to VisionMax'
       else
         puts "WARNING: skipping test_retrieve_accession_number_with_dot, edsagr db isn't in the profile."
@@ -243,7 +243,7 @@ class EdsApiTests < Minitest::Test
   #   VCR.use_cassette('record_test/profile_2/test_record_with_publication_status') do
   #     session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
   #     if session.dbid_in_profile 'edsstc'
-  #       record = session.retrieve({dbid: 'edsstc', an: '946928'})
+  #       record = session.retrieve(dbid: 'edsstc', an: '946928')
   #       assert record.eds_publication_status == 'PREPRINT'
   #     else
   #       puts "WARNING: skipping test_record_with_publication_status, edsstc db isn't in the profile."
@@ -256,7 +256,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_2/test_record_with_series_info') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
       if session.dbid_in_profile 'edsbeb'
-        record = session.retrieve({dbid: 'edsbeb', an: 'edsbeb.B9789004314924.s017'})
+        record = session.retrieve(dbid: 'edsbeb', an: 'edsbeb.B9789004314924.s017')
         assert record.eds_series == 'DQR Studies in Literature'
       else
         puts "WARNING: skipping test_record_with_series_info, edsbeb db isn't in the profile."
@@ -269,7 +269,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_2/test_record_with_subject_search_links') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi', decode_sanitize_html: true})
       if session.dbid_in_profile 'bas'
-        record = session.retrieve({dbid: 'bas', an: 'BAS899713'})
+        record = session.retrieve(dbid: 'bas', an: 'BAS899713')
         assert record.eds_subjects.start_with?('<searchLink fieldcode="SH"')
         assert record.eds_subjects.include?('Anthropology &amp; Sociology')
       else
@@ -283,7 +283,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_2/test_record_with_subject_search_links_with_link_tag') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi', decode_sanitize_html: true})
       if session.dbid_in_profile 'hap'
-        record = session.retrieve({dbid: 'hap', an: 'hap.359464'})
+        record = session.retrieve(dbid: 'hap', an: 'hap.359464')
         assert record.eds_subjects.start_with?('<searchLink fieldcode="DE"')
         assert record.eds_subjects.include?('Emigrant remittances')
       else
@@ -301,7 +301,7 @@ class EdsApiTests < Minitest::Test
       # <Group>Su</Group>
       session_a = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi', decode_sanitize_html: true})
       if session_a.dbid_in_profile 'aph'
-        record_a = session_a.retrieve({dbid: 'aph', an: '123200654'})
+        record_a = session_a.retrieve(dbid: 'aph', an: '123200654')
         assert record_a.eds_subjects_geographic.start_with?('<searchLink fieldcode="DE"')
         assert record_a.eds_subjects_geographic.include?('MALDIVES')
       else
@@ -314,7 +314,7 @@ class EdsApiTests < Minitest::Test
       # <Group>Su</Group>
       session_b = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi', decode_sanitize_html: true})
       if session_b.dbid_in_profile 'edsgcc'
-        record_b = session_b.retrieve({dbid: 'edsgcc', an: 'edsgcl.299362683'})
+        record_b = session_b.retrieve(dbid: 'edsgcc', an: 'edsgcl.299362683')
         assert record_b.eds_subjects_geographic.start_with?('<searchLink fieldcode="DE"')
         assert record_b.eds_subjects_geographic.include?('Canada')
       else
@@ -328,7 +328,7 @@ class EdsApiTests < Minitest::Test
     VCR.use_cassette('record_test/profile_4/test_record_with_citation_ris') do
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'eds_api', decode_sanitize_html: true})
       if session.dbid_in_profile 'edsgao'
-        record = session.retrieve({dbid: 'edsgao', an: 'edsgcl.536108598'})
+        record = session.retrieve(dbid: 'edsgao', an: 'edsgcl.536108598')
         assert record.eds_citation_exports.items.first['data'].include?('AU  - Hui, Pinhong')
       else
         puts "WARNING: skipping test_record_with_citation_ris, edsgao db isn't in the profile."
@@ -342,7 +342,7 @@ class EdsApiTests < Minitest::Test
       session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
       if session.dbid_in_profile 'edsbeb'
         assert_raises(EBSCO::EDS::NotFound) do
-          session.retrieve({dbid: 'edsbeb', an: 'edsbeb.B9789004314924.s017zzz'})
+          session.retrieve(dbid: 'edsbeb', an: 'edsbeb.B9789004314924.s017zzz')
         end
       else
         puts "WARNING: skipping test_record_not_found test, edsbeb db isn't in the profile."
@@ -355,7 +355,7 @@ class EdsApiTests < Minitest::Test
   #   VCR.use_cassette('record_test/profile_2/test_record_with_no_searchlinks') do
   #     session = EBSCO::EDS::Session.new({guest: false, use_cache: false, profile: 'edsapi'})
   #     if session.dbid_in_profile 'edswss'
-  #       record = session.retrieve({dbid: 'edswss', an: '000306525900003'})
+  #       record = session.retrieve(dbid: 'edswss', an: '000306525900003')
   #       puts 'RECORD: ' +  record.inspect
   #       puts 'SUBJECTS: ' + record.eds_subjects.to_s
   #       assert record.eds_subjects.include?('&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22DISTANCE-DECAY%22&quot;&gt;DISTANCE-DECAY&lt;/searchLink&gt;')


### PR DESCRIPTION
Fixes #112 

Currently, any upstream codebase using this gem is unable to keep pace with the latest Ruby development because the gem only supports Ruby 2.x, partly due to the net-http-persistent pin in the gemspec.

This commit bumps the `net-http-persistent` dependency to allow both 3.x (>= 3.1) and 4.x, the latter of which supports Ruby 3. That is half the battle. The other half: this commit also changes method calls within the gem to use keyword arguments instead of hashes.

I ran the test suite under both Ruby 3.0 and 2.7 and it passed under both, so this should be backwards compatible, though fair warning: I did not test under other 2.x rubies. (Btw, I am doing this work to let the team at Stanford upgrade SearchWorks to Ruby 3.0.)

Let me know if I can do any other work or testing to move this forward. Thank you for considering this PR!