### PR TITLE
Remove deprecated codecov ruby uploader

### DIFF
--- a/ebsco-eds.gemspec
+++ b/ebsco-eds.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.0'
-  spec.add_development_dependency 'codecov', '~> 0.1'
   spec.add_development_dependency 'vcr', '~> 5.0', '>= 5.0.0'
   spec.add_development_dependency 'minitest-vcr', '~> 1.4', '>= 1.4.0'
   spec.add_development_dependency 'webmock', '~> 3.6'


### PR DESCRIPTION
This is no longer supported by codecov

See https://github.com/codecov/codecov-ruby/blob/master/README.md