### PR TITLE
add eds_pub_date_facet

### DIFF
--- a/lib/ebsco/eds/options.rb
+++ b/lib/ebsco/eds/options.rb
@@ -336,6 +336,10 @@ module EBSCO
                 end
               end
 
+              if value.has_key?('eds_pub_date_facet')
+                _my_limiters.push({:Id => 'DT1', :Values => value['eds_pub_date_facet']})
+              end
+
               # date limiters
               if value.has_key?('eds_publication_year_range_facet')
                 _list = value['eds_publication_year_range_facet']
@@ -437,6 +441,7 @@ module EBSCO
                   filter_id += 1
                 end
               end
+
               # PublicationYear
               if value.has_key?('eds_publication_year_facet')
                 year_list = value['eds_publication_year_facet']


### PR DESCRIPTION
We want to be able to have a facet that is month based. For example, in May we would have May 2025, April 2025, March 2025. In order to do this we need to be able to pass a month-date pair to the api, i.e. 2025-04/2025-04. This allows this but also allows for flexibility (say if someone wanted the last two months, etc). 